### PR TITLE
add ellipsis arg to blob_read()

### DIFF
--- a/R/blob_read.R
+++ b/R/blob_read.R
@@ -17,6 +17,13 @@
 #' @param stage Store to access, either `dev` (default) or `prod`.
 #' @param container Container name (`character`) or actual container class object to read from
 #' @param progress_show show progress bar (`logical`) (default = TRUE)
+#' @param ... Additional arguments passed to the respective reader functions:
+#'   - For `.parquet` files: Passed to `arrow::read_parquet()`.
+#'   - For `.geojson` files: Passed to `sf::st_read()`.
+#'   - For `.json` files: Passed to `jsonlite::read_json()`.
+#'   - For `.csv` files: Passed to `readr::read_csv()`.
+#'   - For `.xls` files: Passed to `readxl::read_xls()`.
+#'   - For `.xlsx` files: Passed to `readxl::read_xlsx()`.
 #'
 #' @returns Data frame.
 #' @examples
@@ -27,7 +34,7 @@
 #'                 )
 #'
 #' @export
-blob_read <- function(name, stage = c("dev", "prod"), container="projects", progress_show = TRUE) {
+blob_read <- function(name, stage = c("dev", "prod"), container="projects", progress_show = TRUE, ...) {
   stage <- rlang::arg_match(stage)
   if(inherits(container, "character")){
     container <- blob_containers(stage = stage)[[container]]
@@ -48,12 +55,12 @@ blob_read <- function(name, stage = c("dev", "prod"), container="projects", prog
 
 
   switch(fileext,
-         parquet = arrow::read_parquet(tf),
-         geojson = sf::st_read(tf, quiet = TRUE),
-         json = dplyr::as_tibble(jsonlite::read_json(tf, simplifyVector = TRUE)),
-         csv = readr::read_csv(tf, col_types = readr::cols(), guess_max = 10000),
-         xls = readxl::read_xls(tf, col_types = "guess"),
-         xlsx = readxl::read_xlsx(tf, col_types = "guess")
+         parquet = arrow::read_parquet(tf, ...),
+         geojson = sf::st_read(tf, quiet = TRUE,....),
+         json = dplyr::as_tibble(jsonlite::read_json(tf, simplifyVector = TRUE),..),
+         csv = readr::read_csv(tf, col_types = readr::cols(), guess_max = 10000,...),
+         xls = readxl::read_xls(tf, col_types = "guess",...),
+         xlsx = readxl::read_xlsx(tf, col_types = "guess", ...)
   )
 }
 

--- a/man/blob_read.Rd
+++ b/man/blob_read.Rd
@@ -8,7 +8,8 @@ blob_read(
   name,
   stage = c("dev", "prod"),
   container = "projects",
-  progress_show = TRUE
+  progress_show = TRUE,
+  ...
 )
 }
 \arguments{
@@ -20,6 +21,14 @@ and file extension, such as `.parquet`.}
 \item{container}{Container name (`character`) or actual container class object to read from}
 
 \item{progress_show}{show progress bar (`logical`) (default = TRUE)}
+
+\item{...}{Additional arguments passed to the respective reader functions:
+- For `.parquet` files: Passed to `arrow::read_parquet()`.
+- For `.geojson` files: Passed to `sf::st_read()`.
+- For `.json` files: Passed to `jsonlite::read_json()`.
+- For `.csv` files: Passed to `readr::read_csv()`.
+- For `.xls` files: Passed to `readxl::read_xls()`.
+- For `.xlsx` files: Passed to `readxl::read_xlsx()`.}
 }
 \value{
 Data frame.


### PR DESCRIPTION
by providing the ellipsis `...` arg to `blob_read()` we can add additional arguments relative to the different readers. Specifically made for the use-case of needing to add `as_data_frame = FALSE` to `arrow::read_parquet()` to get it recognized as an `sf` class object