### PR TITLE
tmp update pg calling syntax

### DIFF
--- a/man/get_sas_key.Rd
+++ b/man/get_sas_key.Rd
@@ -7,7 +7,7 @@ Convenience function get SAS key based on stage.
 TODO: will eventually creat some credential registration step to make this
 more flexible, but this will work well internally for now}
 \usage{
-get_sas_key(stage, key_syntax_v = 3, write_access)
+get_sas_key(stage, key_syntax_v = 3, write_access = TRUE)
 }
 \arguments{
 \item{stage}{Store to access, either `prod` (default) or `dev`. `dev`}

--- a/man/pg_con.Rd
+++ b/man/pg_con.Rd
@@ -4,7 +4,7 @@
 \alias{pg_con}
 \title{pg_con - connect to postgres DB. Either `prod` or `dev` stage}
 \usage{
-pg_con(stage = "prod", key_syntax_v = 2, write = TRUE)
+pg_con(stage = "prod", key_syntax_v = 3, write = FALSE)
 }
 \arguments{
 \item{stage}{db to access, either `prod` (default) or `dev`. `dev`}
@@ -13,7 +13,7 @@ pg_con(stage = "prod", key_syntax_v = 2, write = TRUE)
 naming status}
 
 \item{write_access}{`logical` indicating if write access is needed
-default=TRUE}
+default=FALSE}
 }
 \value{
 `PqConnection` object

--- a/man/pg_creds.Rd
+++ b/man/pg_creds.Rd
@@ -4,13 +4,13 @@
 \alias{pg_creds}
 \title{pg_creds}
 \usage{
-pg_creds(stage = "prod", key_syntax_v = 2, write_access = TRUE)
+pg_creds(stage = "prod", key_syntax_v = 3, write_access = FALSE)
 }
 \arguments{
 \item{stage}{db to access, either `prod` (default) or `dev`. `dev`}
 
-\item{key_syntax_v}{`integer` 1 or 2 (default). 2 is the current env var
-naming status}
+\item{key_syntax_v}{`integer` 1, 2, or 3 (default). 3 is the latest env var
+naming status. 1 & 2 will be deprecated.}
 
 \item{write_access}{`logical` indicating if write access is needed
 default=TRUE}


### PR DESCRIPTION
update pg calling/env var naming syntax. Should deprecate syntax 1 & 2 arguments as no longer work, but will put working version on main for now in case anyone is using it. 