### PR TITLE
Improve seas5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,6 @@ Description: More about what it does (maybe more than one line)
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.3
 Depends: 
     R (>= 2.10)

--- a/R/load_oni.R
+++ b/R/load_oni.R
@@ -12,7 +12,7 @@
 #' load_oni()
 load_oni <-  function(show_col_types = TRUE){
   readr::read_table(
-    "https://origin.cpc.ncep.noaa.gov/products/analysis_monitoring/ensostuff/detrend.nino34.ascii.txt",
+    "https://www.cpc.ncep.noaa.gov/products/analysis_monitoring/ensostuff/detrend.nino34.ascii.txt",
     show_col_types = show_col_types
     )  |>
     janitor::clean_names() |>

--- a/R/seas5.R
+++ b/R/seas5.R
@@ -58,7 +58,7 @@ seas5_aggregate_forecast <-  function(df,value= "mean",valid_months=c(3,4,5), by
 #'   connect to main by default
 #' @param iso3 `character` iso3 code for country
 #' @param adm_level `numeric` administrative level
-#' @param adm_name `character` admin name of interest
+#' @param adm_name `character` admin name of interest, if null (default) returns all admin names in that level and iso3
 #' @param convert_units `logical` should we convert from m/s to mm/month
 #'   default = TRUE
 #'
@@ -77,9 +77,11 @@ pg_load_seas5_historical <- function(
     con=NULL,
     iso3,
     adm_level,
-    adm_name,
+    adm_name = NULL,
     convert_units =TRUE
     ){
+  
+  iso3 = toupper(iso3)
 
   if(is.null(con)){
     con <- pg_con()
@@ -87,12 +89,19 @@ pg_load_seas5_historical <- function(
   df_lookup <- blob_load_admin_lookup() |>
     janitor::clean_names()
 
+
   df_lookup_filt <- df_lookup |>
     dplyr::filter(
       iso3 %in% {{iso3}},
-      !!rlang::sym(glue::glue("adm{adm_level}_name")) %in% adm_name,
       adm_level == {{adm_level}}
-    ) |>
+    )
+  if(!is.null(adm_name)){
+    df_lookup_filt <- df_lookup_filt |> 
+      dplyr::filter(
+        !!rlang::sym(glue::glue("adm{adm_level}_name")) %in% adm_name,
+      )
+  }
+  df_lookup_filt <- df_lookup_filt |> 
     dplyr::select(
       dplyr::matches("adm\\d"),-adm0_name,-adm0_pcode
     ) |>

--- a/man/pg_load_seas5_historical.Rd
+++ b/man/pg_load_seas5_historical.Rd
@@ -8,7 +8,7 @@ pg_load_seas5_historical(
   con = NULL,
   iso3,
   adm_level,
-  adm_name,
+  adm_name = NULL,
   convert_units = TRUE
 )
 }
@@ -20,7 +20,7 @@ connect to main by default}
 
 \item{adm_level}{`numeric` administrative level}
 
-\item{adm_name}{`character` admin name of interest}
+\item{adm_name}{`character` admin name of interest, if null (default) returns all admin names in that level and iso3}
 
 \item{convert_units}{`logical` should we convert from m/s to mm/month
 default = TRUE}


### PR DESCRIPTION
This pull request introduces improvements to the `pg_load_seas5_historical` function, focusing on enhanced flexibility for administrative name filtering and better documentation. The most notable changes include making the `adm_name` parameter optional, updating the filtering logic to accommodate this, and refining the documentation to clarify the new behavior.

**Functionality improvements:**

* Made the `adm_name` parameter in `pg_load_seas5_historical` optional by setting its default value to `NULL`, allowing users to retrieve all admin names for a given level and country if not specified. [[1]](diffhunk://#diff-98f1c9e32290e6177d074cf23691661e6fc5f66d1e84ec424a03c8c2bdae3fe0L80-R104) [[2]](diffhunk://#diff-1096c0e4ad91dd93268a7a30ab7b1bd4c518d19276cfc2f5aadae1fbcef78abdL11-R11)
* Updated the filtering logic in `pg_load_seas5_historical` to only filter by `adm_name` when it is provided, increasing flexibility for users.

**Documentation updates:**

* Updated the documentation in `man/pg_load_seas5_historical.Rd` to reflect the new behavior of the `adm_name` parameter, clarifying its default value and effect. [[1]](diffhunk://#diff-1096c0e4ad91dd93268a7a30ab7b1bd4c518d19276cfc2f5aadae1fbcef78abdL23-R23) [[2]](diffhunk://#diff-98f1c9e32290e6177d074cf23691661e6fc5f66d1e84ec424a03c8c2bdae3fe0L61-R61)
* Updated the `DESCRIPTION` file to reflect the new Roxygen version used for documentation generation.

**Minor update:**

* Updated the data source URL in `load_oni` to use the canonical domain for improved reliability.